### PR TITLE
Use JS to set Safari cookie.

### DIFF
--- a/components/AllowWalletAccess.vue
+++ b/components/AllowWalletAccess.vue
@@ -32,7 +32,9 @@ export default {
       // set cookie to enable cross-domain storage access on Safari
       // Note: This cookie is only used by Safari. It must be accessible to
       // JavaScript (not http-only) in order for storage access to work
-      // properly.
+      // properly. Safari will only persist this cookie for 7 days per:
+      // https://www.cookiestatus.com/safari/#first-party-cookies
+      // But setting it in JS allows for the mediator to be a static site.
       document.cookie = 'v=1;secure;sameSite=None';
       window.close();
     }

--- a/components/AllowWalletAccess.vue
+++ b/components/AllowWalletAccess.vue
@@ -29,6 +29,11 @@ export default {
   name: 'AllowWalletAccess',
   methods: {
     async onClose() {
+      // set cookie to enable cross-domain storage access on Safari
+      // Note: This cookie is only used by Safari. It must be accessible to
+      // JavaScript (not http-only) in order for storage access to work
+      // properly.
+      document.cookie = 'v=1;secure;sameSite=None';
       window.close();
     }
   }

--- a/lib/http.js
+++ b/lib/http.js
@@ -32,12 +32,6 @@ bedrock.events.on('bedrock-express.start', async app => {
       // send with no content
       return res.send('');
     }
-    /* Note: This cookie is only used by Safari. It must be set here by the
-    server with these attributes. It cannot be set in JavaScript or it
-    will get a forced 7-day expiration by Safari. It must be accessible to
-    JavaScript (not http-only) in order for storage access to work properly. */
-    // set cookie to enable cross-domain storage access on Safari
-    res.cookie('v', '1', {secure: true, sameSite: 'None'});
     // render main page
     res.render('main.html');
   });


### PR DESCRIPTION
- Switch from setting a cookie server side to setting a cookie with JS.
- This cookie is to address a Safari storage access issue.

- This change is difficult to test since the issue being addressed is somewhat opaque.
- A cookie is still required in current Safari versions.  The server and JS cookies seem to behave the same way with basic testing.
- There could be temporal issues with cookie timeouts or expirations, which are difficult to test.
- The fix has no effect on current Firefox and Chrome.
- This change allows the site to be fully static.