### PR TITLE
Add chapi native bridge / WebShare button.

### DIFF
--- a/components/Mediator.vue
+++ b/components/Mediator.vue
@@ -299,21 +299,12 @@ export default {
     },
     async webShare() {
       const {credential} = this;
-      let file;
-      if(credential.type === 'web' &&
-         credential.dataType === 'VerifiablePresentation') {
-        const vp = credential.data;
-        const blob = new Blob(
-          [JSON.stringify(vp, null, 2)],
-          {type: 'text/plain'}
-        );
-        file = new File([blob], 'SharedVerifiablePresentation.txt',
-          {type: 'text/plain'});
-      } else {
-        console.log(
-          'Use of WebShare API with this credential type not supported.');
-        return false;
-      }
+      const blob = new Blob(
+        [JSON.stringify({credential}, null, 2)],
+        {type: 'text/plain'}
+      );
+      const file = new File([blob], 'SharedVerifiablePresentation.txt',
+        {type: 'text/plain'});
 
       const data = {files: [file]};
 

--- a/components/Mediator.vue
+++ b/components/Mediator.vue
@@ -298,12 +298,12 @@ export default {
       await navigator.credentialMediator.hide();
     },
     async webShare() {
-      const {credential} = this;
+      const {credential, relyingOrigin: credentialRequestOrigin} = this;
+      const payload = {credential, credentialRequestOrigin};
       const blob = new Blob(
-        [JSON.stringify({credential}, null, 2)],
-        {type: 'text/plain'}
-      );
-      const file = new File([blob], 'SharedVerifiablePresentation.txt',
+        [JSON.stringify(payload, null, 2)],
+        {type: 'text/plain'});
+      const file = new File([blob], 'SharedCredentialRequest.txt',
         {type: 'text/plain'});
 
       const data = {files: [file]};


### PR DESCRIPTION
Add a 'Share with Native App' button.
(The initial iteration of this used `.html` files, but this turned out to not be needed UI-wise -- simplified to use `.txt` files.)

Left for future PRs:
- Hiding the 'Share with native app' button if the browser is not able to share (detected via `if(navigator.canShare && navigator.canShare({files: data.files}))`)
- Returning the result of the 'store()' operation to the caller (currently prints the result to the console). 